### PR TITLE
Add 64-bit Linux binaries for mira 4.9.5

### DIFF
--- a/urls.tsv
+++ b/urls.tsv
@@ -613,7 +613,7 @@ mira	4.0	darwin	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/
 mira	4.0	linux	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0_linux-gnu_x86_64_static.tar.bz2	.tar.bz2	01b416b2d21e6bbf0a4450e5ed161ac16afd44f0f90eec02af45f1623f65627e	True
 mira	4.0.2	darwin	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0.2_darwin13.1.0_x86_64_static.tar.bz2	.tar.bz2	3cdfba4be7bde1a97b15259b9fd3216c4369d906ea20f5f360f30dc0d83e7b8e	True
 mira	4.0.2	linux	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0.2_linux-gnu_x86_64_static.tar.bz2	.tar.bz2	d3c74a6b402192e01d10adb8dbdc3450d4033fa0e7662ce5ce5de4f8c1967813	True
-mira	4.9.5	linux	x64	https://www.dropbox.com/s/g4w5bn57wxzz6q3/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2?dl=02	3848885cb041cd9bf7aa8f220dd3f084443f5060fa433b669f7d28880ba4c61f	False
+mira	4.9.5	linux	x64	https://www.dropbox.com/s/g4w5bn57wxzz6q3/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2?dl=02	.tar.bz2	3848885cb041cd9bf7aa8f220dd3f084443f5060fa433b669f7d28880ba4c61f	False
 moments	0.13	src	all	https://github.com/bgruening/download_store/raw/master/miclip/moments_0.13.tar.gz	.tar.gz	44001f6dc48a9b27c338b6f1cca97aabf803715622eb5c1421e7d65be723ea16	True
 mono	4.0	src	all	http://download.mono-project.com/sources/mono/mono-4.0.1.tar.bz2	.tar.bz2	ff1f15f3b8d43c6a2818c00fabe377b2d8408ad14acd9d507658b4cae00f5bce	True
 monocle	1.0.0	src	all	https://github.com/bgruening/download_store/raw/master/monocle/monocle_1.0.0.tar.gz	.tar.gz	ab606f36dc54fe3e703294ab6334804c3967da7cc6038f1600cdb1080f3b271e	True

--- a/urls.tsv
+++ b/urls.tsv
@@ -613,6 +613,7 @@ mira	4.0	darwin	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/
 mira	4.0	linux	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0_linux-gnu_x86_64_static.tar.bz2	.tar.bz2	01b416b2d21e6bbf0a4450e5ed161ac16afd44f0f90eec02af45f1623f65627e	True
 mira	4.0.2	darwin	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0.2_darwin13.1.0_x86_64_static.tar.bz2	.tar.bz2	3cdfba4be7bde1a97b15259b9fd3216c4369d906ea20f5f360f30dc0d83e7b8e	True
 mira	4.0.2	linux	x64	/srv/nginx/depot.galaxyproject.org/root/package/sourceforge/mira_4.0.2_linux-gnu_x86_64_static.tar.bz2	.tar.bz2	d3c74a6b402192e01d10adb8dbdc3450d4033fa0e7662ce5ce5de4f8c1967813	True
+mira	4.9.5	linux	x64	https://www.dropbox.com/s/g4w5bn57wxzz6q3/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2?dl=02	3848885cb041cd9bf7aa8f220dd3f084443f5060fa433b669f7d28880ba4c61f	False
 moments	0.13	src	all	https://github.com/bgruening/download_store/raw/master/miclip/moments_0.13.tar.gz	.tar.gz	44001f6dc48a9b27c338b6f1cca97aabf803715622eb5c1421e7d65be723ea16	True
 mono	4.0	src	all	http://download.mono-project.com/sources/mono/mono-4.0.1.tar.bz2	.tar.bz2	ff1f15f3b8d43c6a2818c00fabe377b2d8408ad14acd9d507658b4cae00f5bce	True
 monocle	1.0.0	src	all	https://github.com/bgruening/download_store/raw/master/monocle/monocle_1.0.0.tar.gz	.tar.gz	ab606f36dc54fe3e703294ab6334804c3967da7cc6038f1600cdb1080f3b271e	True


### PR DESCRIPTION
This is no longer on the SourceForge page, sadly. Using Dropbox as short term solution to getting the file into the cache.

Originally at:

http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2

See also:

https://github.com/peterjc/galaxy_mira/blob/master/packages/package_mira_4_9_5/tool_dependencies.xml

See mailing list discussion:

https://lists.galaxyproject.org/pipermail/galaxy-dev/2016-August/024754.html