### PR TITLE
Added MSGFPlus, MS/MS proteomics search tool

### DIFF
--- a/urls.tsv
+++ b/urls.tsv
@@ -137,7 +137,7 @@ MACS2	2.1.0	src	all	https://pypi.python.org/packages/source/M/MACS2/MACS2-2.1.0.
 MACS	1.3.7.1	src	all	http://depot.galaxyproject.org/package/source/MACS-1.3.7.1.tar.gz	.tar.gz	8070453d76b36544e2e88e265524b957158cc64ba8907a7da0db9e6845ffda38	True
 MASS	7.3-39	src	all	https://github.com/bgruening/download_store/raw/master/monocle/MASS_7.3-39.tar.gz	.tar.gz	936bc972aa2a5154603c3fddd31a515aaf001b5515714ad19a05857d5022d11d	True
 MASS	7.3-44	src	all	https://github.com/bgruening/download_store/raw/master/DESeq2-1_8_1/MASS_7.3-44.tar.gz	.tar.gz	835fe22547222742fa84b8bf77774432abe3dff267932b8b8ed06de554f8e79b	True
-MSGFPlus	2016.10.26	src	all	http://proteomics.ucsd.edu/SoftwBBare/MSGFPlus/MSGFPlus.zip	.zip	bbcfcb984a0e41e67f6ccfea0998e416e29ddfc304b344df7c5352c81ecccdd7	False
+MSGFPlus	2016.10.26	src	all	https://omics.pnl.gov/sites/default/files/MSGFPlus.zip	.zip	bbcfcb984a0e41e67f6ccfea0998e416e29ddfc304b344df7c5352c81ecccdd7	False
 MUMmer	3.23	src	all	http://depot.galaxyproject.org/package/sourceforge/MUMmer3.23.tar.gz	.tar.gz	1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f	True
 Matrix	1.1-5	src	all	http://depot.galaxyproject.org/package/noarch/Matrix_1.1-5.tar.gz	.tar.gz	b23ea59a5218be916a3e6ac4d5f573c5e7921b1eca9a2ed918f2d8f8ef520b4f	True
 MiClip	1.2	src	all	https://github.com/bgruening/download_store/raw/master/miclip/MiClip_1.2.tar.gz	.tar.gz	60dcaf33483369fd7ed73a198049962eb6490e87da35e2827e084d7d1ef55f33	True

--- a/urls.tsv
+++ b/urls.tsv
@@ -137,6 +137,7 @@ MACS2	2.1.0	src	all	https://pypi.python.org/packages/source/M/MACS2/MACS2-2.1.0.
 MACS	1.3.7.1	src	all	http://depot.galaxyproject.org/package/source/MACS-1.3.7.1.tar.gz	.tar.gz	8070453d76b36544e2e88e265524b957158cc64ba8907a7da0db9e6845ffda38	True
 MASS	7.3-39	src	all	https://github.com/bgruening/download_store/raw/master/monocle/MASS_7.3-39.tar.gz	.tar.gz	936bc972aa2a5154603c3fddd31a515aaf001b5515714ad19a05857d5022d11d	True
 MASS	7.3-44	src	all	https://github.com/bgruening/download_store/raw/master/DESeq2-1_8_1/MASS_7.3-44.tar.gz	.tar.gz	835fe22547222742fa84b8bf77774432abe3dff267932b8b8ed06de554f8e79b	True
+MSGFPlus	2016.10.26	src	all	http://proteomics.ucsd.edu/SoftwBBare/MSGFPlus/MSGFPlus.zip	.zip	bbcfcb984a0e41e67f6ccfea0998e416e29ddfc304b344df7c5352c81ecccdd7	False
 MUMmer	3.23	src	all	http://depot.galaxyproject.org/package/sourceforge/MUMmer3.23.tar.gz	.tar.gz	1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f	True
 Matrix	1.1-5	src	all	http://depot.galaxyproject.org/package/noarch/Matrix_1.1-5.tar.gz	.tar.gz	b23ea59a5218be916a3e6ac4d5f573c5e7921b1eca9a2ed918f2d8f8ef520b4f	True
 MiClip	1.2	src	all	https://github.com/bgruening/download_store/raw/master/miclip/MiClip_1.2.tar.gz	.tar.gz	60dcaf33483369fd7ed73a198049962eb6490e87da35e2827e084d7d1ef55f33	True


### PR DESCRIPTION
Forgot to put this in a branch, but here is a tool for the cargo port. There is a bioconda recipe for it, but the original download page offers the same URL even if the pkg is updated (also the reason use_upstream is set to False here), so it would be good to have it versioned in the depot.