### PR TITLE
Cache NCBI BLAST+ 2.7.1 tar-balls for x86

### DIFF
--- a/urls.tsv
+++ b/urls.tsv
@@ -342,6 +342,8 @@ blast_plus	2.6.0	darwin	x64	ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/
 blast_plus	2.6.0	linux	x64	ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-x64-linux.tar.gz	.tar.gz	3e5dd522da10bb02ee01abd81c1b62ef30f8c69a77c198b2cc1c5a3fa1eb4a67	True
 blast_plus	2.7.0	darwin	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.0/ncbi-blast-2.7.0+-x64-macosx.tar.gz	.tar.gz	c295aa858638a8194d6b4abbefedaa2759e67ee2932e3553ffbc4afa138b20ee	True
 blast_plus	2.7.0	linux	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.0/ncbi-blast-2.7.0+-x64-linux.tar.gz	.tar.gz	cf61c3a687dae6475e73b571bf06ff92cbbb74a2cdc557f1059d0f12485eb10e	True
+blast_plus	2.7.1	darwin	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-macosx.tar.gz	.tar.gz	90696a27b9b7d20ea2919893f1377279	True
+blast_plus	2.7.1	linux	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-linux.tar.gz	.tar.gz	9d31dff42ab2b0d9565f761ce340e4ba	True
 blockbuster	0.0.1	src	all	https://github.com/bgruening/download_store/raw/master/blockbuster/blockbuster-0.0.1.tar.gz	.tar.gz	68829bf4286ea61369a9ca583698fcebf79015df3d89d1e908510fb7c84bdadf	True
 blockclust	1.0-data-celWS235	src	all	https://github.com/bgruening/download_store/raw/master/blockclust/blockclust-data-1.0/annotations/celWS235.tar.gz	.tar.gz	937769091b9f9b5f33a03ebe21bd6fecc103e13fb205facffa614ef44c86f98f	True
 blockclust	1.0-data-dm3	src	all	https://github.com/bgruening/download_store/raw/master/blockclust/blockclust-data-1.0/annotations/dm3.tar.gz	.tar.gz	70e0b2d90a76ba3004ee9e6cb43a78f99ab6280291f0207197dd546c1eb407b6	True

--- a/urls.tsv
+++ b/urls.tsv
@@ -342,8 +342,8 @@ blast_plus	2.6.0	darwin	x64	ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/
 blast_plus	2.6.0	linux	x64	ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-x64-linux.tar.gz	.tar.gz	3e5dd522da10bb02ee01abd81c1b62ef30f8c69a77c198b2cc1c5a3fa1eb4a67	True
 blast_plus	2.7.0	darwin	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.0/ncbi-blast-2.7.0+-x64-macosx.tar.gz	.tar.gz	c295aa858638a8194d6b4abbefedaa2759e67ee2932e3553ffbc4afa138b20ee	True
 blast_plus	2.7.0	linux	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.0/ncbi-blast-2.7.0+-x64-linux.tar.gz	.tar.gz	cf61c3a687dae6475e73b571bf06ff92cbbb74a2cdc557f1059d0f12485eb10e	True
-blast_plus	2.7.1	darwin	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-macosx.tar.gz	.tar.gz	90696a27b9b7d20ea2919893f1377279	True
-blast_plus	2.7.1	linux	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-linux.tar.gz	.tar.gz	9d31dff42ab2b0d9565f761ce340e4ba	True
+blast_plus	2.7.1	darwin	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-macosx.tar.gz	.tar.gz	1de96e0168771d02e1e4d5796e01c6f09073ce61f74aaba23c541750973554ea	True
+blast_plus	2.7.1	linux	x64	https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-linux.tar.gz	.tar.gz	1df64183dcb1ee9493813b850bd83e7b83d3c04ea26f2ad7d2b5d0a6d53de917	True
 blockbuster	0.0.1	src	all	https://github.com/bgruening/download_store/raw/master/blockbuster/blockbuster-0.0.1.tar.gz	.tar.gz	68829bf4286ea61369a9ca583698fcebf79015df3d89d1e908510fb7c84bdadf	True
 blockclust	1.0-data-celWS235	src	all	https://github.com/bgruening/download_store/raw/master/blockclust/blockclust-data-1.0/annotations/celWS235.tar.gz	.tar.gz	937769091b9f9b5f33a03ebe21bd6fecc103e13fb205facffa614ef44c86f98f	True
 blockclust	1.0-data-dm3	src	all	https://github.com/bgruening/download_store/raw/master/blockclust/blockclust-data-1.0/annotations/dm3.tar.gz	.tar.gz	70e0b2d90a76ba3004ee9e6cb43a78f99ab6280291f0207197dd546c1eb407b6	True


### PR DESCRIPTION
Cross reference #134 for NCBI BLAST+ 2.7.0 which the NCBI later pulled in favour of this new BLAST+ 2.7.1 release.