### PR TITLE
add default PR text + fix build to not ignore errors

### DIFF
--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -6,4 +6,4 @@ git remote add origin2 $GIT_REMOTE
 # Fetch from it
 git fetch --quiet origin2
 # And diff against that
-git diff origin2/master urls.tsv | grep -v '^+++' | grep '^+' | galaxy-cachefile-external-validator
+git diff origin2/master urls.tsv | grep -v '^+++' | grep '^+' | bin/galaxy-cachefile-external-validator

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+- [ ] This software or dataset is not more easily backed up by other systems (e.g. a conda package which could more easily be mirrored by a conda mirror)
+- [ ] This software or dataset's license allows us to distribute it. If possible please link to it.
+- [ ] This software or dataset is related to the sciences, galaxy, or similar areas.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: python
 python: 2.7
-script: .ci/build.sh; .ci/check.sh
+install:
+- python setup.py install
+
+script:
+- .ci/build.sh
+- .ci/check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python: 2.7
-install:
-- python setup.py install
 
 script:
 - .ci/build.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+We have some restrictions on the uploaded software. Please ensure that it meets the following requirements before adding it to urls.tsv:
+
+- [ ] This software is not more easily backed up by other systems (e.g. a conda package which could more easily be mirrored by a conda mirror)
+- [ ] This software's or dataset's license allows us to distribute it. If possible please link to it.
+- [ ] This software or dataset is related to the sciences, galaxy, or similar areas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-We have some restrictions on the uploaded software. Please ensure that it meets the following requirements before adding it to urls.tsv:
-
-- [ ] This software is not more easily backed up by other systems (e.g. a conda package which could more easily be mirrored by a conda mirror)
-- [ ] This software's or dataset's license allows us to distribute it. If possible please link to it.
-- [ ] This software or dataset is related to the sciences, galaxy, or similar areas.

--- a/urls.tsv
+++ b/urls.tsv
@@ -430,7 +430,7 @@ coreutils	8.22	src	all	https://github.com/bgruening/download_store/raw/master/GN
 coreutils	8.25	src	all	https://github.com/mvdbeek/galaxy_package_sources/raw/master/package_gnu_coreutils_8_25/coreutils_8.25_src_all.tar.bz2	.tar.bz2	031a9842298864ed0d7ae87e008759465c8b4716ed4bf97d723fe8ced5145e94	False
 cran_kernlab	0.1.4	src	all	http://cran.r-project.org/src/contrib/Archive/kernlab/kernlab_0.1-4.tar.gz	.tar.gz	a522c22270050968a30118a16546054b82a01bcb845e975ba06584acc91169cf	True
 cran_yacca	1.0	src	all	http://cran.r-project.org/src/contrib/Archive/yacca/yacca_1.0.tar.gz	.tar.gz	e47f80e69fea87f1775d4439e6739914e734eac42832954b31f2a11df9011808	True
-crap	0.1.0	all	all	https://raw.githubusercontent.com/pravs3683/cRAP/master/cRAP_protein_database.fasta	.fasta	2f346d83abc0f4d742a93d07e4a6ccb879c030932b8fffc5a93734b67e6eefc5	True
+crap	0.1.0	src	all	https://raw.githubusercontent.com/pravs3683/cRAP/master/cRAP_protein_database.fasta	.fasta	2f346d83abc0f4d742a93d07e4a6ccb879c030932b8fffc5a93734b67e6eefc5	True
 ctc	1.44.0	src	all	https://bioc.ism.ac.jp/packages/3.2/bioc/src/contrib/ctc_1.44.0.tar.gz	.tar.gz	0f67391d3fd6bc970293b5eb11dcd14f15686b61bce1c6da03e16dc3a60e93f2	True
 cufflinks	2.1.1	darwin	x64	http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.1.1.OSX_x86_64.tar.gz	.tar.gz	5955a2650c548b4f50a8407ce7302855590e7eca325ee9db6a6edfd54653218e	True
 cufflinks	2.1.1	linux	x64	http://depot.galaxyproject.org/package/linux/x86_64/cufflinks/cufflinks-2.1.1.tgz	.tar.gz	8e32e92ab6265e7f011938cdac72888a348da9c1d193906638cbd10450554607	True


### PR DESCRIPTION
for whatever reason some small errors were being silently ignored.

E.g.

- https://github.com/galaxyproject/cargo-port/pull/117 has a travis log which indicates that urls.tsv failed to validated but it marked it as success anyway.
