### PR TITLE
Support verifying md5 hashes in addition to sha256

### DIFF
--- a/.conda/get_meta.sh
+++ b/.conda/get_meta.sh
@@ -11,6 +11,17 @@ else
     cd bioconda-recipes
 fi
 
+# Set $RECIPE to only get meta for a specific recipe, useful for testing/development.
+if [ -n "$RECIPE" ]; then
+    meta="recipes/${RECIPE}/meta.yaml"
+    if [ -f "$meta" ]; then
+        echo "$meta"
+        exit 0
+    fi
+    echo "ERROR: no meta.yaml for ${RECIPE}" >&2
+    exit 1
+fi
+
 # We are not running regularly enough to do this.
 # Were we running this more regularly it (will?) make sense.
 #git log --name-only --pretty="" --since="2 months ago" | grep -E '^recipes/.*/meta.yaml'

--- a/.conda/to_cargoport.py
+++ b/.conda/to_cargoport.py
@@ -2,6 +2,9 @@
 import sys
 import yaml
 
+DEFAULT_HASH_TYPE = 'sha256'
+HASH_TYPE_ORDER = ('sha256', 'md5')
+
 
 def pickOne(url):
     # Pick one
@@ -41,6 +44,14 @@ for element in sorted(yaml.load(sys.stdin), key=lambda el: el['name']):
     elif platform == 'linux-64':
         platform = 'linux'
 
+    hash_value = ''
+    for hash_type in HASH_TYPE_ORDER:
+        if element.get(hash_type):
+            if hash_type == DEFAULT_HASH_TYPE:
+                hash_value = element[hash_type]
+            else:
+                hash_value = '%ssum:%s' % (hash_type, element[hash_type])
+
     print '\t'.join([
         element['name'],
         element['version'],
@@ -48,6 +59,6 @@ for element in sorted(yaml.load(sys.stdin), key=lambda el: el['name']):
         arch,
         pickOne(element['url']),
         extDetect(element['url']),
-        "",
+        hash_value,
         "True"
     ])

--- a/bin/process_urls.py
+++ b/bin/process_urls.py
@@ -13,6 +13,7 @@ if sys.version_info.major > 2:
     from builtins import object
 
 from cargoport.utils import (download_url, 
+    package_hash_type,
     package_to_path, 
     symlink_depot, 
     verify_file, 
@@ -76,11 +77,15 @@ def main(galaxy_package_file):
                     continue
 
                 # Check sha256sum of download
-                err = verify_file(output_package_path, ld['sha256sum'].strip())
-                if err is not None:
-                    xunit.error(nice_name, "Sha256sumError", err)
-                    cleanup_file(output_package_path)
-                    continue
+                hash_type, hash_value = package_hash_type(ld)
+                if hash_type is not None:
+                    err = verify_file(output_package_path, hash_value, hash_type=hash_type)
+                    if err is not None:
+                        xunit.error(nice_name, "Sha256sumError", err)
+                        cleanup_file(output_package_path)
+                        continue
+                else:
+                    log.warning("No hash provided for package %s", nice_name)
 
                 xunit.ok(nice_name)
 


### PR DESCRIPTION
- [ ] This software or dataset's license allows us to distribute it. (Insert link to link to license here)
- [ ] This software or dataset is related to the biological sciences, galaxy, or similar areas.
- [x] N/A

This change makes it possible to verify against an MD5 hash instead of a SHA256. It also will automatically use MD5 hashes from bioconda recipes if a sha256 hash is not specified in the recipe. It will also refuse to download an archive if a hash is not provided in the TSV.

Automatic mirroring via Bioconda recipes is broken because the stored hash (an empty string) does not match the actual download's hash. At first I thought this was a problem only for Bioconductor packages because the current Bioconductor package recipes only include an md5 and not a sha256 in their `meta.yaml`s but then I discovered that the conda-to-cargo-port scripts [never actually write the sha256 hash](https://github.com/galaxyproject/cargo-port/blob/1464ad22dbdcb667aae11383bb3e8cdb20604cb9/.conda/to_cargoport.py#L51) to check against. So I can't figure out how the bioconda mirroring ever worked for any package. If someone knows what is going on that would be nice since I'm not confident my changes here aren't going to break anything.

The hash verification failure is the cause of the issue reported in galaxyproject/galaxy-hub#721. Right now the daily Jenkins job that runs to update cargo-port pulls all of the new versions of Bioconductor packages but fails to store them because of the hash verification failure, then repeats again the next day:

```
INFO:root:URL missing, downloading https://bioconductor.org/packages/3.12/bioc/src/contrib/annotate_1.68.0.tar.gz to bioconductor-annotate/bioconductor-annotate_1.68.0_src_all.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1828k  100 1828k    0     0  15.9M      0 --:--:-- --:--:-- --:--:-- 15.9M
INFO:root:File hash d4fc1309f27b560a7438e2b8ec60f99aad09a79bad2b625115a398d2432a14e7
ERROR:root:File has bad hash! d4fc1309f27b560a7438e2b8ec60f99aad09a79bad2b625115a398d2432a14e7 !=  in bioconductor-annotate/bioconductor-annotate_1.68.0_src_all.tar.gz
```

This change should fix that error. Note that non-Bioconductor pacakges and anything else that does not fetch from Git (the process for which does not do hash verification) is failing similarly. So again, I have no idea how this ever worked for Bioconda packages.