### PR TITLE
Distinguish more platforms and architectures

### DIFF
--- a/.conda/merge_dups.py
+++ b/.conda/merge_dups.py
@@ -2,45 +2,56 @@
 
 import yaml
 
-linux = yaml.safe_load(open('data_linux-64.yml', 'r'))
-res = yaml.safe_load(open('data_osx-.yml', 'r'))
-res.extend(linux)
-
-# Remove duplicates
 unique_packages = {}
-for package in res:
-    # This information is the unique portion, so we key on that
-    key_data = [
-        package['version'],
-        package['name']
-    ]
 
-    if isinstance(package['url'], list):
-        key_data += package['url']
-    else:
-        key_data.append(package['url'])
+for meta_file in [
+    'data_linux-64.yml',
+    'data_linux-aarch64.yml',
+    'data_osx-64.yml',
+    'data_osx-arm64.yml'
+]:
+    res = yaml.safe_load(open(meta_file, 'r'))
 
-    key = '|'.join(key_data)
-    # We turn the architecture item into a list.
-    if key in unique_packages:
-        unique_packages[key]['arch'].append(package['arch'])
-    else:
-        unique_packages[key] = package
-        unique_packages[key]['arch'] = [unique_packages[key]['arch']]
+    # Remove duplicates
+    for package in res:
+        # This information is the unique portion, so we key on that
+        key_data = [
+            package['version'],
+            package['name']
+        ]
+
+        if isinstance(package['url'], list):
+            key_data += package['url']
+        else:
+            key_data.append(package['url'])
+
+        key = '|'.join(key_data)
+        # maintain set of architectures seen for this particular key
+        if key in unique_packages:
+            unique_packages[key]['arch'].add(package['arch'])
+        else:
+            unique_packages[key] = package
+            unique_packages[key]['arch'] = {unique_packages[key]['arch']}
 
 res = []
 for item in unique_packages.values():
     if len(item['arch']) == 1:
-        # If there is only one arch, then we have a platform specific URL,
-        # since otherwise we would have generated an arch that contains both
-        # linux + osx
-        item['arch'] = item['arch'][0]
-        res.append(item)
+        # If there is only one arch, then we already have a platform specific URL.
+        # We just extract the single identifier from the set.
+        item['arch'] = item['arch'].pop()
+    elif item['arch'] == {'linux-64', 'linux-aarch64'}:
+        item['arch'] = 'linux-x64'
+    elif item['arch'] == {'osx-64', 'osx-arm64'}:
+        item['arch'] = 'osx-x64'
+    elif item['arch'] == {'linux-64', 'linux-aarch64'}:
+        item['arch'] = 'linux-x64'
+    elif item['arch'] == {'linux-64', 'linux-aarch64'}:
+        item['arch'] = 'linux-x64'
     else:
-        # Here we have two or more archs (ideally. We don't check conditions
-        # like 0 arches)
-        item['arch'] = 'src'
-        res.append(item)
+        # likely source code
+        #(could  there be combinations beyond the above ones that mean something else?)
+        item['arch'] = 'src-all'
+    res.append(item)
 
 with open('data.yml', 'w') as outfile:
     yaml.safe_dump(res, outfile, default_flow_style=False)

--- a/.conda/run.sh
+++ b/.conda/run.sh
@@ -7,8 +7,10 @@ export CONDA_VERSION_TO_INSTALL=25.3.1-0
 
 ./.conda/install.sh
 ./.conda/get_meta.sh | sort -u > meta_files.list
-CONDA_SUBDIR=linux-64 python ./.conda/get_urls.py meta_files.list linux-64
-CONDA_SUBDIR=osx- python ./.conda/get_urls.py meta_files.list osx-
+CONDA_SUBDIR=linux-64 python ./.conda/get_urls.py meta_files.list
+CONDA_SUBDIR=linux-aarch64 python ./.conda/get_urls.py meta_files.list
+CONDA_SUBDIR=osx-64 python ./.conda/get_urls.py meta_files.list
+CONDA_SUBDIR=osx-arm64 python ./.conda/get_urls.py meta_files.list
 python ./.conda/merge_dups.py
 
 python ./.conda/to_cargoport.py < data.yml > urls-bioconda.tsv

--- a/.conda/to_cargoport.py
+++ b/.conda/to_cargoport.py
@@ -33,16 +33,14 @@ def extDetect(url):
 
 
 for element in sorted(yaml.safe_load(sys.stdin), key=lambda el: el['name']):
-    {'url': 'https://github.com/arq5x/lumpy-sv/66c83c8.tar.gz', 'version': '0.2.12', 'arch': 'linux-64', 'name': 'lumpy-sv'}
+    # example element
+    # {'url': 'https://github.com/arq5x/lumpy-sv/66c83c8.tar.gz', 'version': '0.2.12', 'arch': 'linux-64', 'name': 'lumpy-sv'}
     # Id	Version	Platform	Architecture	Upstream Url	Extension	sha256sum	Use upstream
-    platform = element['arch']
-    arch = 'x64'
-    if platform == 'src':
-        arch = 'all'
-    elif platform == 'osx-':
+    platform, arch = element['arch'].split('-')
+    if platform == 'osx':
         platform = 'darwin'
-    elif platform == 'linux-64':
-        platform = 'linux'
+    if arch == '64':
+        arch = 'x86_64'
 
     hash_value = ''
     for hash_type in HASH_TYPE_ORDER:


### PR DESCRIPTION
Some bioconda recipes today use aarch64/arm64 specific code, which needs to be handled.

Currently, no urls and checksums can be extracted for recipes like https://github.com/bioconda/bioconda-recipes/blob/master/recipes/vclust/meta.yaml.
