### PR TITLE
Generate checksum files during processing of urls

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -10,8 +10,8 @@ cat index.html.tpl | sed "s|BUILD_TAG_GOES_HERE|Build <a href='${BUILD_URL}'>#${
 # Copy over all changed files to the target
 rsync -avr --exclude bioconda-recipes --exclude .git --exclude Miniforge3.sh . $CPC_HOST:$CPC_DIR/
 
-# Any one-time upgrades
-ssh $CPC_HOST "cd $CPC_DIR && sh upgrade.sh"
+# Updating SHA256SUM.txt files now done as part of process_urls.py
+# ssh $CPC_HOST "cd $CPC_DIR && sh upgrade.sh"
 
 # Process URLs and copy back report
 ssh $CPC_HOST "cd $CPC_DIR && PYTHONPATH=. python bin/process_urls.py urls.tsv > api-tcp.json"

--- a/bin/process_urls.py
+++ b/bin/process_urls.py
@@ -53,7 +53,9 @@ def main(galaxy_package_file):
             if os.path.isfile(checksum_file):
                 with open(checksum_file) as checksums:
                     for line in checksums:
-                        checksums_data.append(line.strip().split())
+                        package_checksum_data = line.strip().split()
+                        if package_checksum_data not in checksums_data:
+                            checksums_data.append(package_checksum_data)
 
             for ld in package_data:
                 nice_name = package_to_path(**ld)

--- a/bin/process_urls.py
+++ b/bin/process_urls.py
@@ -6,6 +6,9 @@ import logging
 import os
 import subprocess
 import sys
+
+from itertools import groupby
+
 # Conditional import to ensure we can run without non-stdlib on py2k.
 if sys.version_info.major > 2:
     from builtins import str
@@ -42,55 +45,70 @@ def main(galaxy_package_file):
         retcode = 0
         xunit = XUnitReportBuilder()
 
-        for ld in yield_packages(handle):
-            nice_name = package_to_path(**ld)
+        for package_id, package_data in groupby(yield_packages(handle), key=lambda x: x['id']):
+            if not os.path.exists(package_id):
+                os.makedirs(package_id)
+            checksum_file = os.path.join(package_id, 'SHA256SUM.txt')
+            checksums_data = []
+            if os.path.isfile(checksum_file):
+                with open(checksum_file) as checksums:
+                    for line in checksums:
+                        checksums_data.append(line.strip().split())
 
-            if not os.path.exists(ld['id']):
-                os.makedirs(ld['id'])
+            for ld in package_data:
+                nice_name = package_to_path(**ld)
 
-            output_package_path = os.path.join(ld['id'], nice_name) + ld['ext']
-            visited_paths.append(os.path.abspath(output_package_path))
+                output_package_path = os.path.join(ld['id'], nice_name) + ld['ext']
+                visited_paths.append(os.path.abspath(output_package_path))
 
-            tmpld = {}
-            tmpld.update(ld)
-            tmpld['_gen'] = output_package_path
-            api_data['data'].append(tmpld)
+                tmpld = {}
+                tmpld.update(ld)
+                tmpld['_gen'] = output_package_path
+                api_data['data'].append(tmpld)
 
-            if os.path.exists(output_package_path) and os.path.getsize(output_package_path) == 0:
-                log.error("Empty download, removing %s %s", ld['url'], output_package_path)
-                cleanup_file(output_package_path)
-
-            hash_type, hash_value = package_hash_type(ld)
-
-            if os.path.exists(output_package_path):
-                log.debug("URL exists %s", ld['url'])
-                xunit.skip(nice_name)
-            elif hash_type is None:
-                err = "No hash provided for '%s', package will not be downloaded" % nice_name
-                log.error(err)
-                xunit.error(nice_name, "Sha256sumError", err)
-            else:
-                log.info("URL missing, downloading %s to %s", ld['url'], output_package_path)
-
-                if ld['url'].startswith('/'):
-                    err = symlink_depot(ld['url'], output_package_path)
-                else:
-                    err = download_url(ld['url'], output_package_path)
-
-                if err is not None:
-                    xunit.failure(nice_name, "DownloadError", err)
+                if os.path.exists(output_package_path) and os.path.getsize(output_package_path) == 0:
+                    log.error("Empty download, removing %s %s", ld['url'], output_package_path)
                     cleanup_file(output_package_path)
-                    continue
 
-                # Check sha256sum of download
-                err = verify_file(output_package_path, hash_value, hash_type=hash_type)
+                hash_type, hash_value = package_hash_type(ld)
 
-                if err is not None:
+                if os.path.exists(output_package_path):
+                    log.debug("URL exists %s", ld['url'])
+                    xunit.skip(nice_name)
+                elif hash_type is None:
+                    err = "No hash provided for '%s', package will not be downloaded" % nice_name
+                    log.error(err)
                     xunit.error(nice_name, "Sha256sumError", err)
-                    cleanup_file(output_package_path)
-                    continue
+                else:
+                    log.info("URL missing, downloading %s to %s", ld['url'], output_package_path)
 
-                xunit.ok(nice_name)
+                    if ld['url'].startswith('/'):
+                        err = symlink_depot(ld['url'], output_package_path)
+                    else:
+                        err = download_url(ld['url'], output_package_path)
+
+                    if err is not None:
+                        xunit.failure(nice_name, "DownloadError", err)
+                        cleanup_file(output_package_path)
+                        continue
+
+                    # Check sha256sum of download
+                    err = verify_file(output_package_path, hash_value, hash_type=hash_type)
+
+                    if err is not None:
+                        xunit.error(nice_name, "Sha256sumError", err)
+                        cleanup_file(output_package_path)
+                        continue
+
+                    package_checksum_data = [hash_value, nice_name + ld['ext']]
+                    if package_checksum_data not in checksums_data:
+                        checksums_data.append(package_checksum_data)
+
+                    xunit.ok(nice_name)
+
+            with open(checksum_file, 'w') as checksums:
+                for package_checksum_data in sorted(checksums_data, key=lambda x: x[1]):
+                    checksums.write('\t'.join(package_checksum_data) + '\n')
 
         with open('report.xml', 'w') as xunit_handle:
             xunit_handle.write(xunit.serialize())


### PR DESCRIPTION
This will handle bioconda urls correctly and persistently.

The old upgrade.sh code wiped out all checksum files before writing them freshly. This meant that checksums for older uploads could get lost. For bioconda packages, specifically, the old code had an error and wrote urls.tsv twice instead of writing them once followed by urls-bioconda.